### PR TITLE
Simplify interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,25 +21,24 @@ import (
 )
 
 func main() {
-	c := &qbit.Config{
+	config := &qbit.Config{
 		URL:     "http://localhost:8080",
 		User:    "admin",
 		Pass:    "qbitpassword",
-		Timeout: qbit.Duration{15 * time.Second},
 	}
 
-	q, err := qbit.New(c)
+	qbit, err := qbit.New(config)
 	if err != nil {
 		log.Fatalln("[ERROR]", err)
 	}
 
-	_, xfers, err := q.GetXfers()
+	xfers, err := qbit.GetXfers()
 	if err != nil {
 		log.Fatalln("[ERROR]", err)
 	}
 
-	for _, x := range xfers {
-		log.Println(x.Name, x.Progress)
+	for _, xfer := range xfers {
+		log.Println(xfer.Name, xfer.Progress)
 	}
 }
 ```

--- a/qbit.go
+++ b/qbit.go
@@ -5,7 +5,6 @@ package qbit
 
 import (
 	"context"
-	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -16,7 +15,6 @@ import (
 	"time"
 
 	"golang.org/x/net/publicsuffix"
-	"golift.io/datacounter"
 )
 
 // Package defaults.
@@ -29,30 +27,22 @@ var (
 	ErrLoginFailed = fmt.Errorf("authentication failed")
 )
 
-// Logger is an optional generic interface to allow this library to log debug messages.
-type Logger func(msg string, fmt ...interface{})
-
 // Config is the input data needed to return a Qbit struct.
 // This is setup to allow you to easily pass this data in from a config file.
 type Config struct {
-	URL       string   `json:"url" toml:"url" xml:"url" yaml:"url"`
-	User      string   `json:"user" toml:"user" xml:"user" yaml:"user"`
-	Pass      string   `json:"pass" toml:"pass" xml:"pass" yaml:"pass"`
-	HTTPPass  string   `json:"http_pass" toml:"http_pass" xml:"http_pass" yaml:"http_pass"`
-	HTTPUser  string   `json:"http_user" toml:"http_user" xml:"http_user" yaml:"http_user"`
-	Timeout   Duration `json:"timeout" toml:"timeout" xml:"timeout" yaml:"timeout"`
-	VerifySSL bool     `json:"verify_ssl" toml:"verify_ssl" xml:"verify_ssl" yaml:"verify_ssl"`
-	DebugLog  Logger   `json:"-" toml:"-" xml:"-" yaml:"-"`
+	URL      string       `json:"url" toml:"url" xml:"url" yaml:"url"`
+	User     string       `json:"user" toml:"user" xml:"user" yaml:"user"`
+	Pass     string       `json:"pass" toml:"pass" xml:"pass" yaml:"pass"`
+	HTTPPass string       `json:"http_pass" toml:"http_pass" xml:"http_pass" yaml:"http_pass"`
+	HTTPUser string       `json:"http_user" toml:"http_user" xml:"http_user" yaml:"http_user"`
+	Client   *http.Client `json:"-" toml:"-" xml:"-" yaml:"-"`
 }
 
 // Qbit is what you get in return for passing in a valid Config to New().
 type Qbit struct {
 	config *Config
-	*client
+	client *client
 }
-
-// Duration is used to parse durations from a config file.
-type Duration struct{ time.Duration }
 
 type client struct {
 	auth   string
@@ -110,12 +100,6 @@ type Xfer struct {
 	Upspeed           int64   `json:"upspeed"`
 }
 
-// UnmarshalText parses a duration type from a config file.
-func (d *Duration) UnmarshalText(data []byte) (err error) {
-	d.Duration, err = time.ParseDuration(string(data))
-	return
-}
-
 func NewNoAuth(config *Config) (*Qbit, error) {
 	return newConfig(config, false)
 }
@@ -141,21 +125,18 @@ func newConfig(config *Config, login bool) (*Qbit, error) {
 		auth = ""
 	}
 
-	if config.Timeout.Duration == 0 {
-		config.Timeout.Duration = DefaultTimeout
+	httpClient := config.Client
+	if httpClient == nil {
+		httpClient = &http.Client{}
 	}
+
+	httpClient.Jar = jar
 
 	qbit := &Qbit{
 		config: config,
 		client: &client{
-			auth: auth,
-			Client: &http.Client{
-				Transport: &http.Transport{
-					TLSClientConfig: &tls.Config{InsecureSkipVerify: config.VerifySSL}, //nolint:gosec
-				},
-				Jar:     jar,
-				Timeout: config.Timeout.Duration,
-			},
+			auth:   auth,
+			Client: httpClient,
 		},
 	}
 
@@ -168,7 +149,7 @@ func newConfig(config *Config, login bool) (*Qbit, error) {
 
 // login is called once from New().
 func (q *Qbit) login() error {
-	ctx, cancel := context.WithTimeout(context.Background(), q.config.Timeout.Duration)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
 	post := strings.NewReader("username=" + q.config.User + "&password=" + q.config.Pass)
@@ -180,7 +161,7 @@ func (q *Qbit) login() error {
 
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
-	resp, err := q.Do(req)
+	resp, err := q.client.Do(req)
 	if err != nil {
 		return fmt.Errorf("login failed: %w", err)
 	}
@@ -214,37 +195,36 @@ func (c *client) Do(req *http.Request) (*http.Response, error) {
 }
 
 // GetXfers returns data about all transfers/downloads in the Qbit client.
-func (q *Qbit) GetXfers() (int64, []*Xfer, error) {
+func (q *Qbit) GetXfers() ([]*Xfer, error) {
+	return q.GetXfersContext(context.Background())
+}
+
+// GetXfersContext returns data about all transfers/downloads in the Qbit client.
+func (q *Qbit) GetXfersContext(ctx context.Context) ([]*Xfer, error) {
 	if !q.client.cookie {
 		if err := q.login(); err != nil {
-			return 0, nil, err
+			return nil, err
 		}
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), q.config.Timeout.Duration)
-	defer cancel()
-
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, q.config.URL+"api/v2/torrents/info", nil)
 	if err != nil {
-		return 0, nil, fmt.Errorf("creating info request: %w", err)
+		return nil, fmt.Errorf("creating info request: %w", err)
 	}
 
 	req.URL.RawQuery = "filter=all"
 
-	resp, err := q.Do(req)
+	resp, err := q.client.Do(req)
 	if err != nil {
-		return 0, nil, fmt.Errorf("info req failed: %w", err)
+		return nil, fmt.Errorf("info req failed: %w", err)
 	}
 	defer resp.Body.Close()
 
 	xfers := []*Xfer{}
-	counter := datacounter.NewReaderCounter(resp.Body)
-
-	decoder := json.NewDecoder(counter)
-	if err := decoder.Decode(&xfers); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&xfers); err != nil {
 		q.client.cookie = false
-		return int64(counter.Count()), nil, fmt.Errorf("decoding body failed: %w", err)
+		return nil, fmt.Errorf("decoding body failed: %w", err)
 	}
 
-	return int64(counter.Count()), xfers, nil
+	return xfers, nil
 }


### PR DESCRIPTION
This removes the timeout and verify_ssl inputs and replaces them with an http.Client.
Also removes the body size output since you can obtain that through the custom http client.