### PR TITLE
Handle 204 No Content response for qBittorrent login

### DIFF
--- a/qbit.go
+++ b/qbit.go
@@ -174,6 +174,13 @@ func (q *Qbit) login(ctx context.Context) error {
 
 	body, _ := io.ReadAll(resp.Body)
 
+	// qBittorrent 5.2.0+ returns 204 No Content (with an empty body) on a
+	// successful login, instead of the previous 200 OK with "Ok." in the
+	// body. Accept 204 as success without requiring the old body match.
+	if resp.StatusCode == http.StatusNoContent {
+		return nil
+	}
+
 	if resp.StatusCode != http.StatusOK || !strings.Contains(string(body), "Ok.") {
 		return fmt.Errorf("%w: %s: %s: %s", ErrLoginFailed, resp.Status, req.URL, string(body))
 	}


### PR DESCRIPTION
qBittorrent 5.2.0 changed /api/v2/auth/login to return "204 No Content" on success instead of"200 OK" with "Ok." in the body. This breaks login(), which only accepts the old 200+"Ok." response — so auth fails here even with correct credentials, even though qBittorrent actually logged in fine and set a valid session cookie.

Fix: Treat the 204 response as a successful login. Existing 200/"Ok." check is untouched, ensuring older qBittorrent versions are unaffected.

This same qBittorrent 5.2.0 change has already caused the same auth failure in other projects — see Radarr ([#11339](https://github.com/Radarr/Radarr/issues/11339)), Whisparr ([#1082](https://github.com/Whisparr/Whisparr/issues/1082)), and Homepage ([discussion #6650](https://github.com/gethomepage/homepage/discussions/6650)).

I tested locally against qBittorrent 5.2.x (login + GetXfers work) and an older qBittorrent version (no change in behavior) to confirm functionality.